### PR TITLE
Added option in Document.Download() for getting the document with the…

### DIFF
--- a/CSLibrary/Document.cs
+++ b/CSLibrary/Document.cs
@@ -199,12 +199,12 @@ namespace SignNow
         /// <param name="SaveFileName">File Name without Extension</param>
         /// <param name="ResultFormat">JSON, XML</param>
         /// <returns>Collapsed document in PDF format saved to a the location provided.</returns>
-        public static dynamic Download(string AccessToken, string DocumentId, string SaveFilePath = "", string SaveFileName = "my-collapsed-document", string ResultFormat = "JSON")
+        public static dynamic Download(string AccessToken, string DocumentId, bool WithHistory = false, string SaveFilePath = "", string SaveFileName = "my-collapsed-document", string ResultFormat = "JSON")
         {
             var client = new RestClient();
             client.BaseUrl = new Uri(Config.ApiHost);
 
-            var request = new RestRequest("/document/" + DocumentId + "/download?type=collapsed", Method.GET)
+            var request = new RestRequest("/document/" + DocumentId + "/download" + (WithHistory ? "/collapsed?with_history=1" : "?type=collapsed"), Method.GET)
                 .AddHeader("Accept", "application/json")
                 .AddHeader("Authorization", "Bearer " + AccessToken);
 

--- a/Examples/Examples.cs
+++ b/Examples/Examples.cs
@@ -117,9 +117,14 @@ namespace Examples
 
             //Download Document
             ConsoleH2("Downloading Document");
-            JObject downloadDocRes = SignNow.Document.Download(AccessToken, DocumentId, "/", "sample");
+            JObject downloadDocRes = SignNow.Document.Download(AccessToken, DocumentId, false, "/", "sample");
             Console.WriteLine("Download Document: {0} \r\n\r\n\r\n", downloadDocRes["file"].ToString());
-            
+
+            //Download Document With History
+            ConsoleH2("Downloading Document With History");
+            JObject downloadDocWithHistoryRes = SignNow.Document.Download(AccessToken, DocumentId, true, "/", "sample");
+            Console.WriteLine("Download Document With History: {0} \r\n\r\n\r\n", downloadDocWithHistoryRes["file"].ToString());
+
             //Send Free Form Invite
             ConsoleH2("Sending Role-based Invite");
             dynamic inviteDataObj = new


### PR DESCRIPTION
Added option in Document.Download() for getting the document with the history (see https://help.signnow.com/reference#collapsed-document) 